### PR TITLE
add missing template metadata for faz related parameters

### DIFF
--- a/templates/autoscale-existing-vpc.template.yaml
+++ b/templates/autoscale-existing-vpc.template.yaml
@@ -648,6 +648,15 @@ Metadata:
                   - HeartBeatLossCount
                   - HeartBeatDelayAllowance
             - Label:
+                  default: FortiAnalyzer configuration
+              Parameters:
+                  - FortiAnalyzerIntegrationOptions
+                  - FortiAnalyzerVersion
+                  - FortiAnalyzerInstanceType
+                  - FortiAnalyzerAutoscaleAdminUsername
+                  - FortiAnalyzerAutoscaleAdminPassword
+                  - FortiAnalyzerCustomPrivateIpAddress
+            - Label:
                   default: Custom asset location configuration
               Parameters:
                   - UseCustomAssetLocation
@@ -743,6 +752,18 @@ Metadata:
                 default: Custom asset S3 bucket
             CustomAssetDirectory:
                 default: Custom asset folder
+            FortiAnalyzerIntegrationOptions:
+                default: FortiAnalyzer integration
+            FortiAnalyzerVersion:
+                default: FortiAnalyzer version
+            FortiAnalyzerInstanceType:
+                default: FortiAnalyzer instance type
+            FortiAnalyzerCustomPrivateIpAddress:
+                default: FortiAnalyzer custom IP
+            FortiAnalyzerAutoscaleAdminUsername:
+                default: Autoscale admin username
+            FortiAnalyzerAutoscaleAdminPassword:
+                default: Autoscale admin password
 Outputs:
     ResourceTagPrefix:
         Description: >-

--- a/templates/autoscale-existing-vpc.template.yaml
+++ b/templates/autoscale-existing-vpc.template.yaml
@@ -754,12 +754,12 @@ Metadata:
                 default: Custom asset folder
             FortiAnalyzerIntegrationOptions:
                 default: FortiAnalyzer integration
-            FortiAnalyzerVersion:
-                default: FortiAnalyzer version
             FortiAnalyzerInstanceType:
                 default: FortiAnalyzer instance type
+            FortiAnalyzerVersion:
+                default: FortiAnalyzer version
             FortiAnalyzerCustomPrivateIpAddress:
-                default: FortiAnalyzer custom IP
+                default: FortiAnalyzer private IP address
             FortiAnalyzerAutoscaleAdminUsername:
                 default: Autoscale admin username
             FortiAnalyzerAutoscaleAdminPassword:

--- a/templates/autoscale-new-vpc.template.yaml
+++ b/templates/autoscale-new-vpc.template.yaml
@@ -721,6 +721,15 @@ Metadata:
                   - InternalTargetGroupHealthCheckPath
                   - InternalLoadBalancerDnsName
             - Label:
+                  default: FortiAnalyzer configuration
+              Parameters:
+                  - FortiAnalyzerIntegrationOptions
+                  - FortiAnalyzerVersion
+                  - FortiAnalyzerInstanceType
+                  - FortiAnalyzerAutoscaleAdminUsername
+                  - FortiAnalyzerAutoscaleAdminPassword
+                  - FortiAnalyzerCustomPrivateIpAddress
+            - Label:
                   default: Custom asset location configuration
               Parameters:
                   - UseCustomAssetLocation
@@ -814,6 +823,18 @@ Metadata:
                 default: Custom asset S3 bucket
             CustomAssetDirectory:
                 default: Custom asset folder
+            FortiAnalyzerIntegrationOptions:
+                default: FortiAnalyzer integration
+            FortiAnalyzerVersion:
+                default: FortiAnalyzer version
+            FortiAnalyzerInstanceType:
+                default: FortiAnalyzer instance type
+            FortiAnalyzerCustomPrivateIpAddress:
+                default: FortiAnalyzer custom IP
+            FortiAnalyzerAutoscaleAdminUsername:
+                default: Autoscale admin username
+            FortiAnalyzerAutoscaleAdminPassword:
+                default: Autoscale admin password
 Outputs:
     ResourceTagPrefix:
         Description: >-

--- a/templates/autoscale-new-vpc.template.yaml
+++ b/templates/autoscale-new-vpc.template.yaml
@@ -825,12 +825,12 @@ Metadata:
                 default: Custom asset folder
             FortiAnalyzerIntegrationOptions:
                 default: FortiAnalyzer integration
-            FortiAnalyzerVersion:
-                default: FortiAnalyzer version
             FortiAnalyzerInstanceType:
                 default: FortiAnalyzer instance type
+            FortiAnalyzerVersion:
+                default: FortiAnalyzer version
             FortiAnalyzerCustomPrivateIpAddress:
-                default: FortiAnalyzer custom IP
+                default: FortiAnalyzer private IP address
             FortiAnalyzerAutoscaleAdminUsername:
                 default: Autoscale admin username
             FortiAnalyzerAutoscaleAdminPassword:

--- a/templates/autoscale-tgw-new-vpc.template.yaml
+++ b/templates/autoscale-tgw-new-vpc.template.yaml
@@ -664,6 +664,15 @@ Metadata:
                   - TransitGatewaySupportOptions
                   - TransitGatewayId
             - Label:
+                  default: FortiAnalyzer configuration
+              Parameters:
+                  - FortiAnalyzerIntegrationOptions
+                  - FortiAnalyzerVersion
+                  - FortiAnalyzerInstanceType
+                  - FortiAnalyzerCustomPrivateIpAddress
+                  - FortiAnalyzerAutoscaleAdminUsername
+                  - FortiAnalyzerAutoscaleAdminPassword
+            - Label:
                   default: Custom asset location configuration
               Parameters:
                   - UseCustomAssetLocation
@@ -747,6 +756,18 @@ Metadata:
                 default: Custom asset S3 bucket
             CustomAssetDirectory:
                 default: Custom asset folder
+            FortiAnalyzerIntegrationOptions:
+                default: FortiAnalyzer integration
+            FortiAnalyzerVersion:
+                default: FortiAnalyzer version
+            FortiAnalyzerInstanceType:
+                default: FortiAnalyzer instance type
+            FortiAnalyzerCustomPrivateIpAddress:
+                default: FortiAnalyzer custom IP
+            FortiAnalyzerAutoscaleAdminUsername:
+                default: Autoscale admin username
+            FortiAnalyzerAutoscaleAdminPassword:
+                default: Autoscale admin password
 Outputs:
     ResourceTagPrefix:
         Description: >-

--- a/templates/autoscale-tgw-new-vpc.template.yaml
+++ b/templates/autoscale-tgw-new-vpc.template.yaml
@@ -758,12 +758,12 @@ Metadata:
                 default: Custom asset folder
             FortiAnalyzerIntegrationOptions:
                 default: FortiAnalyzer integration
-            FortiAnalyzerVersion:
-                default: FortiAnalyzer version
             FortiAnalyzerInstanceType:
                 default: FortiAnalyzer instance type
+            FortiAnalyzerVersion:
+                default: FortiAnalyzer version
             FortiAnalyzerCustomPrivateIpAddress:
-                default: FortiAnalyzer custom IP
+                default: FortiAnalyzer private IP address
             FortiAnalyzerAutoscaleAdminUsername:
                 default: Autoscale admin username
             FortiAnalyzerAutoscaleAdminPassword:


### PR DESCRIPTION
There are yet no meta data for those newly added template parameters for FAZ integration.
This bugfix is created to add them back.