### PR TITLE
fix template validation issue when faz integration set to 'no'

### DIFF
--- a/templates/autoscale-existing-vpc.template.yaml
+++ b/templates/autoscale-existing-vpc.template.yaml
@@ -468,6 +468,28 @@ Parameters:
             be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer
             Integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set
             to 'no', any input will be ignored.
+Rules:
+    FortiAnalyzerSupport:
+        RuleCondition: !Equals
+            - !Ref FortiAnalyzerIntegrationOptions
+            - 'yes'
+        Assertions:
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerAutoscaleAdminUsername
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'Autoscale admin username' parameter must not be empty.
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerAutoscaleAdminPassword
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'Autoscale admin password' parameter must not be empty.
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerCustomPrivateIpAddress
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'FortiAnalyzer private IP address' parameter must not be empty.
+
 Conditions:
     GovCloudCondition: !Equals
         - !Ref 'AWS::Region'
@@ -476,6 +498,9 @@ Conditions:
         - !Equals
           - !Ref ResourceTagPrefix
           - ''
+    IfIntegrateFortiAnalyzer: !Equals
+        - !Ref FortiAnalyzerIntegrationOptions
+        - 'yes'
 Resources:
     StackMainWorkload:
         Type: 'AWS::CloudFormation::Stack'
@@ -579,7 +604,10 @@ Resources:
                           - ' '
                           - !Ref FortiAnalyzerVersion
                 FortiAnalyzerAutoscaleAdminUsername: !Ref FortiAnalyzerAutoscaleAdminUsername
-                FortiAnalyzerAutoscaleAdminPassword: !Ref FortiAnalyzerAutoscaleAdminPassword
+                FortiAnalyzerAutoscaleAdminPassword: !If
+                    - IfIntegrateFortiAnalyzer
+                    - !Ref FortiAnalyzerAutoscaleAdminPassword
+                    - 'NoValuePlaceHolderForTemplateParameterWithMinLength'
                 FortiAnalyzerCustomPrivateIpAddress: !Ref FortiAnalyzerCustomPrivateIpAddress
             TemplateURL: !Sub
                 - >-

--- a/templates/autoscale-main.template.yaml
+++ b/templates/autoscale-main.template.yaml
@@ -441,7 +441,7 @@ Parameters:
         Description: The FortiAnalyzer version supported by FortiGate Auto Scaling.
     FortiAnalyzerAutoscaleAdminUsername:
         Type: String
-        AllowedPattern: '^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+        AllowedPattern: '^$|^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
         ConstraintDescription: >-
             This FortiAnalyzer account name can include numbers, lowercase
             letters, uppercase letters, and hyphens (-). It cannot start or end
@@ -466,11 +466,32 @@ Parameters:
     FortiAnalyzerCustomPrivateIpAddress:
         Type: String
         AllowedPattern: >-
-            ^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]){1}$
+            ^$|^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]){1}$
         ConstraintDescription: must be a valid IPv4 format.
         Description: >-
             The static private IP address allocated for the FortiAnalyzer in the
             designated subnet.
+Rules:
+    FortiAnalyzerSupport:
+        RuleCondition: !Equals
+            - !Ref FortiAnalyzerIntegrationOptions
+            - 'yes'
+        Assertions:
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerAutoscaleAdminUsername
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'Autoscale admin username' parameter must not be empty.
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerAutoscaleAdminPassword
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'Autoscale admin password' parameter must not be empty.
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerCustomPrivateIpAddress
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'FortiAnalyzer private IP address' parameter must not be empty.
 Conditions:
     GovCloudCondition: !Equals
         - !Ref 'AWS::Region'

--- a/templates/autoscale-new-vpc.template.yaml
+++ b/templates/autoscale-new-vpc.template.yaml
@@ -481,6 +481,27 @@ Parameters:
             be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer
             Integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set
             to 'no', any input will be ignored.
+Rules:
+    FortiAnalyzerSupport:
+        RuleCondition: !Equals
+            - !Ref FortiAnalyzerIntegrationOptions
+            - 'yes'
+        Assertions:
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerAutoscaleAdminUsername
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'Autoscale admin username' parameter must not be empty.
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerAutoscaleAdminPassword
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'Autoscale admin password' parameter must not be empty.
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerCustomPrivateIpAddress
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'FortiAnalyzer private IP address' parameter must not be empty.
 Conditions:
     GovCloudCondition: !Equals
         - !Ref 'AWS::Region'
@@ -489,6 +510,9 @@ Conditions:
         - !Equals
           - !Ref ResourceTagPrefix
           - ''
+    IfIntegrateFortiAnalyzer: !Equals
+        - !Ref FortiAnalyzerIntegrationOptions
+        - 'yes'
 Resources:
     StackCreateNewVPC:
         Type: 'AWS::CloudFormation::Stack'
@@ -653,7 +677,10 @@ Resources:
                           - ' '
                           - !Ref FortiAnalyzerVersion
                 FortiAnalyzerAutoscaleAdminUsername: !Ref FortiAnalyzerAutoscaleAdminUsername
-                FortiAnalyzerAutoscaleAdminPassword: !Ref FortiAnalyzerAutoscaleAdminPassword
+                FortiAnalyzerAutoscaleAdminPassword: !If
+                    - IfIntegrateFortiAnalyzer
+                    - !Ref FortiAnalyzerAutoscaleAdminPassword
+                    - 'NoValuePlaceHolderForTemplateParameterWithMinLength'
                 FortiAnalyzerCustomPrivateIpAddress: !Ref FortiAnalyzerCustomPrivateIpAddress
             TemplateURL: !Sub
                 - >-

--- a/templates/autoscale-tgw-new-vpc.template.yaml
+++ b/templates/autoscale-tgw-new-vpc.template.yaml
@@ -426,6 +426,28 @@ Parameters:
             be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer
             Integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set
             to 'no', any input will be ignored.
+Rules:
+    FortiAnalyzerSupport:
+        RuleCondition: !Equals
+            - !Ref FortiAnalyzerIntegrationOptions
+            - 'yes'
+        Assertions:
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerAutoscaleAdminUsername
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'Autoscale admin username' parameter must not be empty.
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerAutoscaleAdminPassword
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'Autoscale admin password' parameter must not be empty.
+            - Assert: !Not
+                  - !Equals
+                    - !Ref FortiAnalyzerCustomPrivateIpAddress
+                    - ''
+              AssertDescription: If FortiAnalyzer integration set to 'yes', the 'FortiAnalyzer private IP address' parameter must not be empty.
+
 Conditions:
     GovCloudCondition: !Equals
         - !Ref 'AWS::Region'
@@ -437,6 +459,9 @@ Conditions:
     CreateTransitGateway: !Equals
         - !Ref TransitGatewaySupportOptions
         - create one
+    IfIntegrateFortiAnalyzer: !Equals
+        - !Ref FortiAnalyzerIntegrationOptions
+        - 'yes'
 Resources:
     StackCreateNewVPC:
         Type: 'AWS::CloudFormation::Stack'
@@ -601,7 +626,10 @@ Resources:
                           - ' '
                           - !Ref FortiAnalyzerVersion
                 FortiAnalyzerAutoscaleAdminUsername: !Ref FortiAnalyzerAutoscaleAdminUsername
-                FortiAnalyzerAutoscaleAdminPassword: !Ref FortiAnalyzerAutoscaleAdminPassword
+                FortiAnalyzerAutoscaleAdminPassword: !If
+                    - IfIntegrateFortiAnalyzer
+                    - !Ref FortiAnalyzerAutoscaleAdminPassword
+                    - 'NoValuePlaceHolderForTemplateParameterWithMinLength'
                 FortiAnalyzerCustomPrivateIpAddress: !Ref FortiAnalyzerCustomPrivateIpAddress
             TemplateURL: !Sub
                 - >-


### PR DESCRIPTION
the issue:
the template parameters: Autoscale admin username, Autoscale admin password, and FortiAnalyzer private IP address are conditionally required only when faz integration options set to 'yes'. They should not be required on the other case.
The template validation doesn't match with the condtion above.

the fix: Template parameter checking will apply for both conditions correctly.

the new behavior: The validation won't happen until the deployment is started. For the above conditions, empty value for any of the above three parameters will fail the deployment fast, and with a correct error message for the reason for the failures.