### PR TITLE
Update Lamba Python Runtime to 3.9, Bug Fix

### DIFF
--- a/templates/copy-objects.template.yaml
+++ b/templates/copy-objects.template.yaml
@@ -147,7 +147,7 @@ Resources:
             Role: !GetAtt
                 - CopyObjectsRole
                 - Arn
-            Runtime: python2.7
+            Runtime: python3.9
             Timeout: 240
         Type: 'AWS::Lambda::Function'
     CopyObjectsRole:
@@ -311,13 +311,13 @@ Resources:
                       - "        dest_bucket = event['ResourceProperties']['DestBucket']"
                       - "        if event['RequestType'] == 'Delete':"
                       - '            CheckifVersioned = client.get_bucket_versioning(Bucket=dest_bucket)'
-                      - '            print CheckifVersioned'
+                      - '            print(CheckifVersioned)'
                       - "            if 'Status' in CheckifVersioned:"
-                      - "                print CheckifVersioned['Status']"
-                      - '                print ("This is a versioned Bucket")'
+                      - "                print(CheckifVersioned['Status'])"
+                      - '                print("This is a versioned Bucket")'
                       - '                delete_versionedobjects(dest_bucket)'
                       - '            else:'
-                      - '                print "This is not a versioned bucket"'
+                      - '                print("This is not a versioned bucket")'
                       - '                delete_NonVersionedobjects(dest_bucket)'
                       - '        else:'
                       - '            print("Nothing to do")'
@@ -333,7 +333,7 @@ Resources:
             Role: !GetAtt
                 - S3CleanUpRole
                 - Arn
-            Runtime: python2.7
+            Runtime: python3.9
             Timeout: 240
         Type: 'AWS::Lambda::Function'
     S3CleanUpRole:


### PR DESCRIPTION
python2.7 has been deprecated for deployments of new Lambda functions.  This simple bump to 3.9 coupled w/ the bug fixes to the "print" calls in CleanUpS3BucketFunction seem to be working based on my testing so far.

Addresses #71 .